### PR TITLE
Hotfix readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"


### PR DESCRIPTION
ReadTheDocs build was failing because of Python 3.12. 
This is a known issue: [https://github.com/readthedocs/readthedocs.org/issues/10832](https://github.com/readthedocs/readthedocs.org/issues/10832)

Current fix is to pin the python version to 3.11