### PR TITLE
Solve bug with np scalars in `to_yaml`

### DIFF
--- a/iq_readout/classifiers.py
+++ b/iq_readout/classifiers.py
@@ -71,12 +71,18 @@ class TwoStateClassifier:
         # convert data to lists or floats to avoid having numpy objects
         # inside the YAML file, which do not render correctly
         def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
-            def funct(x):
-                if x.shape == ():
-                    return float(x)
-                return x.tolist()
-            return dumper.represent_list(funct(array))
+            return dumper.represent_list(array.tolist())
         yaml.add_representer(np.ndarray, ndarray_representer)   
+        # the values in "self.params" are np.core.multiarray.scalars,
+        # not "np.ndarray".
+        np_types = [np.int64, np.int32, np.float64, np.float32]
+        for np_type in np_types:
+            def nptype_representer(dumper: yaml.Dumper, scalar: np_type) -> yaml.Node:
+                if "int" in np_type.__name__:
+                    return dumper.represent_int(int(scalar))
+                else:
+                    return dumper.represent_float(float(scalar))
+            yaml.add_representer(np_type, nptype_representer)   
 
         with open(filename, "w") as file:
             yaml.dump(data, file, default_flow_style=False)
@@ -336,6 +342,16 @@ class TwoStateLinearClassifier(TwoStateClassifier):
         def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
             return dumper.represent_list(array.tolist())
         yaml.add_representer(np.ndarray, ndarray_representer)   
+        # the values in "self.params" are np.core.multiarray.scalars,
+        # not "np.ndarray".
+        np_types = [np.int64, np.int32, np.float64, np.float32]
+        for np_type in np_types:
+            def nptype_representer(dumper: yaml.Dumper, scalar: np_type) -> yaml.Node:
+                if "int" in np_type.__name__:
+                    return dumper.represent_int(int(scalar))
+                else:
+                    return dumper.represent_float(float(scalar))
+            yaml.add_representer(np_type, nptype_representer)   
 
         with open(filename, "w") as file:
             yaml.dump(data, file, default_flow_style=False)
@@ -486,6 +502,16 @@ class ThreeStateClassifier:
         def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
             return dumper.represent_list(array.tolist())
         yaml.add_representer(np.ndarray, ndarray_representer)   
+        # the values in "self.params" are np.core.multiarray.scalars,
+        # not "np.ndarray".
+        np_types = [np.int64, np.int32, np.float64, np.float32]
+        for np_type in np_types:
+            def nptype_representer(dumper: yaml.Dumper, scalar: np_type) -> yaml.Node:
+                if "int" in np_type.__name__:
+                    return dumper.represent_int(int(scalar))
+                else:
+                    return dumper.represent_float(float(scalar))
+            yaml.add_representer(np_type, nptype_representer)   
 
         with open(filename, "w") as file:
             yaml.dump(data, file, default_flow_style=False)

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -39,8 +39,8 @@ def test_to_from_yaml(tmp_path):
 
     for clf in clfs:
         clf._param_names = {i: ["a"] for i in range(clf._num_states)}
-        setattr(clf, "statistics", np.array([1., 2.]))
-        clf_1 = clf({i: {"a": 1.} for i in range(clf._num_states)})
+        setattr(clf, "statistics", {"p": np.array([1., 2.])})
+        clf_1 = clf({i: {"a": np.core.multiarray.scalar(np.dtype(np.float64))} for i in range(clf._num_states)})
         clf_1.to_yaml(tmp_path / "clf.yaml")
 
         with open(tmp_path / "clf.yaml", "r") as file:


### PR DESCRIPTION
The PR #48 fixed the problem with numpy arrays, however there was still a problem with numpy scalars, which is solved in this PR.

```
params:
  0:
    angle1: !!python/object/apply:numpy.core.multiarray.scalar
    - &id001 !!python/object/apply:numpy.dtype
      args:
      - f8
      - false
      - true
      state: !!python/tuple
      - 3
      - <
      - null
      - null
      - null
      - -1
      - -1
      - 0
    - !!binary |
      IlMFS2Q89j8=
    angle2: !!python/object/apply:numpy.core.multiarray.scalar
    - *id001
    - !!binary |
      yAt8HYAWwj8=
```

The implementation could not be done using `np.integer` and `np.floating` to check the instance of the objects because `pyyaml` works by identifying the first element of `type(data).__mro__[0]`. This corresponds to the bottom level of class (e.g. `np.int64`) and not to its higher levels (e.g. `np.integer` or `np.generic`). 