### PR TITLE
Hotfix update python version to >=3.10

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9' # install the python version needed
+          python-version: '3.10' # install the python version needed
           
       - name: install python packages
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.8.12"
+requires-python = ">=3.10"
 name = "iq_readout"
 description = "Classifiers for IQ readout data from qubits" 
 version = "0.1.0"


### PR DESCRIPTION
Operand `|` for typing annotations is only supported for `python>=3.10`.